### PR TITLE
Added support for comments when packing

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -199,6 +199,9 @@ namespace LECoal
                     // Empty line
                     if (string.IsNullOrWhiteSpace(line)) { continue; }
 
+                    // Comment
+                    if (line.StartsWith(";") || line.StartsWith("#")) { continue; }
+
                     // Section header
                     if (line.StartsWith('[') && line.EndsWith(']'))
                     {


### PR DESCRIPTION
I have added a line to check for and skip comments when packing files. Not essential, but makes it nicer to make and distribute mods, and comments are a widely accepted part of ini files. 